### PR TITLE
fix: implement auto-scroll to top on page navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "./contexts/ThemeContext";
 
 import Navbar from "./components/Navbar";
 import LanguageModal from "./components/LanguageModal";
+import ScrollToTop from "./components/ScrollToTop";
 import Home from "./pages/Home";
 import Profile from "./pages/Profile";
 import ScanPage from "./pages/ScanPage";
@@ -60,6 +61,8 @@ function App() {
         )}
 
         <Navbar />
+
+        <ScrollToTop />
 
         <Routes>
           <Route path="/" element={<Home />} />

--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Fixed navigation UX issue where pages remained scrolled at previous position. Implemented `ScrollToTop` component to automatically scroll to top (0,0) on all route changes.

## Problem
When navigating via footer or navbar links, pages opened at the previous scroll position, forcing users to manually scroll up to see hero sections and page content.

## Solution
Created `ScrollToTop` component using React Router's `useLocation` hook to detect route changes and trigger automatic scroll to top.

## Changes

**New File:**
- `frontend/src/components/ScrollToTop.jsx` - Auto-scroll component

**Modified File:**
- `frontend/src/App.jsx` - Integrated ScrollToTop component

### Implementation
```jsx
// ScrollToTop.jsx
- Uses useLocation() to detect pathname changes
- Calls window.scrollTo(0, 0) on route change
- Returns null (no UI rendering)

// App.jsx
- Imported ScrollToTop component
- Placed before <Routes> to access Router context
- Triggers on every navigation
```
## Impact
- Better UX - users immediately see page content on navigation without manual scrolling.

Closes #123

@Gagan021-5 please review , thanks!