### PR TITLE
Fix undefined `FILTER_OPTIONS` reference in FilterPanel

### DIFF
--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -230,8 +230,8 @@ const FilterPanel = ({ filters, onFilterChange, isOpen, onClose, isMobile }) => 
 
               {/* Drawer Content */}
               <div className="overflow-y-auto max-h-[calc(80vh-73px)]">
-                {Object.entries(FILTER_OPTIONS).map(([key, data]) =>
-                  renderFilterSection(key, data)
+                {Object.keys(FILTER_DEFINITIONS).map((key) =>
+                  renderFilterSection(key, getFilterCategoryData(key))
                 )}
               </div>
             </motion.div>
@@ -266,8 +266,8 @@ const FilterPanel = ({ filters, onFilterChange, isOpen, onClose, isMobile }) => 
 
       {/* Panel Content */}
       <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
-        {Object.entries(FILTER_OPTIONS).map(([key, data]) =>
-          renderFilterSection(key, data)
+        {Object.keys(FILTER_DEFINITIONS).map((key) =>
+          renderFilterSection(key, getFilterCategoryData(key))
         )}
       </div>
     </div>


### PR DESCRIPTION
#### Summary

This PR fixes a runtime `ReferenceError` in the filter panel caused by an invalid reference to `FILTER_OPTIONS`.

The component now consistently uses `FILTER_DEFINITIONS` together with `getFilterCategoryData(key)`.

#### Root cause

`FILTER_OPTIONS` was referenced in `FilterPanel.jsx`, but it is not defined or exported anywhere in the codebase.
The correct source of filter metadata is `FILTER_DEFINITIONS` from `filterConstants.js`.

#### Changes

* Updated `frontend/src/components/FilterPanel.jsx` to use:

  * `Object.keys(FILTER_DEFINITIONS)`
  * `getFilterCategoryData(key)`
* Removed all remaining usage of the undefined `FILTER_OPTIONS`.

#### Files affected

* `frontend/src/components/FilterPanel.jsx`

`frontend/src/constants/filterConstants.js` was not modified.
It already correctly defines `FILTER_DEFINITIONS` and related helpers.

#### Result
The filter panel no longer throws a `ReferenceError` and behaves the same as before.