### PR TITLE
Coffee category with brand corrections and dietary markers

### DIFF
--- a/frontend/src/data/foodItems.js
+++ b/frontend/src/data/foodItems.js
@@ -338,17 +338,17 @@ const FOOD_ITEMS = {
     { id: 12, name: 'Treasure Cave White Cheddar Cheese', brand: 'Treasure Cave', servingSize: '1/4 cup (28g)', image: yearWhiteCheddar, nutrition: { calories: 100, protein: 6, carbs: 1, totalFat: 8, saturatedFat: 5, transFat: 0, sodium: 380, sugar: 0, fiber: 0 } },
   ],
 
-  'coffee': [
-    { id: 1, name: 'arabica-beans-coffee', brand: 'Starbucks', servingSize: '1 tbsp (5g)', image: arabicaBeansCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 2, name: 'big-bang-ground-beans', brand: "Dunkin'", servingSize: '1 tbsp (5g)', image: bigBangGroundBeans, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 3, name: 'birds-blend-coffee', brand: 'Folgers', servingSize: '1 tsp (2g)', image: birdsBlendCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 4, name: 'black-cat-classic-espresso', brand: 'Peet\'s Coffee', servingSize: '1 tbsp (5g)', image: blackCatClassicEspresso, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 5, name: 'black-magic-cold-brewed', brand: 'Starbucks', servingSize: '1 tbsp (5g)', image: blackMagicColdBrewed, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 6, name: 'blue-nile-blend-whole-been', brand: 'Folgers', servingSize: '1 tbsp (5g)', image: blueNileBlendWholeBeen, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 7, name: 'bright-lights-new-england', brand: 'Lavazza', servingSize: '1 tbsp (7g)', image: brightLightsNewEngland, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 8, name: 'bustelo-cafe-espresso', brand: 'Dunkin\'', servingSize: '1 tbsp (5g)', image: busteloCafeEspresso, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 9, name: 'espresso-whole-bean-coffee', brand: 'Folgers', servingSize: '1 tbsp (5g)', image: espressoWholeBeanCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
-    { id: 10, name: 'everyday-value', brand: 'Starbucks', servingSize: '1/2 cup (120ml)', image: everydayValue, nutrition: { calories: 5, protein: 0, carbs: 1, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 10, sugar: 0, fiber: 0 } },
+'coffee': [
+    { id: 1, name: 'Pike Place Roast Arabica Beans', brand: 'Starbucks', isVegetarian: true, servingSize: '1 tbsp (5g)', image: arabicaBeansCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 2, name: 'Big Bang Medium Roast Grounds', brand: "Peet's Coffee", isVegetarian: true, servingSize: '1 tbsp (5g)', image: bigBangGroundBeans, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 3, name: 'Birds Blend Coffee', brand: 'Birds & Beans', isVegetarian: true, servingSize: '1 tbsp (5g)', image: birdsBlendCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 4, name: 'Black Cat Classic Espresso', brand: 'Intelligentsia', isVegetarian: true, servingSize: '1 tbsp (5g)', image: blackCatClassicEspresso, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 5, name: 'Black Magic Cold Brew', brand: 'Starbucks', isVegetarian: true, servingSize: '12 fl oz (355ml)', image: blackMagicColdBrewed, nutrition: { calories: 5, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 10, sugar: 0, fiber: 0 } },
+    { id: 6, name: 'Blue Nile Blend Whole Bean', brand: "Peet's Coffee", isVegetarian: true, servingSize: '1 tbsp (5g)', image: blueNileBlendWholeBeen, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 7, name: 'Bright Lights New England Roast', brand: 'New England Coffee', isVegetarian: true, servingSize: '1 tbsp (7g)', image: brightLightsNewEngland, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 8, name: 'Café Bustelo Espresso Style', brand: 'Café Bustelo', isVegetarian: true, servingSize: '1 tbsp (5g)', image: busteloCafeEspresso, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 9, name: 'Classic Roast Whole Bean', brand: 'Folgers', isVegetarian: true, servingSize: '1 tbsp (5g)', image: espressoWholeBeanCoffee, nutrition: { calories: 0, protein: 0, carbs: 0, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 0, sugar: 0, fiber: 0 } },
+    { id: 10, name: 'Everyday Value Medium Roast', brand: '365 Whole Foods', isVegetarian: true, servingSize: '1 cup (240ml)', image: everydayValue, nutrition: { calories: 5, protein: 0, carbs: 1, totalFat: 0, saturatedFat: 0, transFat: 0, sodium: 10, sugar: 0, fiber: 0 } },
   ],
 
   'cookies-biscuits': [


### PR DESCRIPTION
Description:
@Gagan021-5 Sir  This PR is related to #198 Continuing the category-by-category database upgrade, this PR perfects the Coffee category. It fixes specific brand-product mismatches and ensures the nutritional data reflects real-world standards for plain coffee.

Key Updates in this Chunk:

- Brand Correction & Resolution:
- Reassigned Big Bang and Blue Nile roasts to Peet's Coffee (previously mislabeled as Dunkin' and Folgers).
- Updated Black Cat Espresso to Intelligentsia and Bustelo to its dedicated Café Bustelo brand.
- Replaced the "Everyday Value" placeholder with the actual 365 Whole Foods brand identity.
- Nutritional Precision: Standardized all plain bean and ground coffee to 0 calories, protein, and fat. Updated liquid entries (Cold Brew and Brewed Coffee) to reflect the minimal caloric and sodium impact (approx. 5 calories per cup) found in processed black coffee.
- Dietary Integrity: Added the isVegetarian: true property to all items. Plain coffee is inherently plant-based and contains no animal-derived additives.
- Standardized Units: Normalized dry serving sizes to 1 tbsp (~5-7g) for consistency across different roast types.

Like This Mark In Now In Coffee
---
<img width="1087" height="714" alt="image" src="https://github.com/user-attachments/assets/067d59e6-f3db-4330-9a41-af05d65025fd" />
<img width="1898" height="856" alt="image" src="https://github.com/user-attachments/assets/4ff69510-f394-4767-985e-571a558cb8c4" />