### PR TITLE
 fix FOUC system-pref sync and add live OS theme listener

### DIFF
--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,28 +1,32 @@
-import { createContext, useContext, useState, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect, useRef } from 'react'
 
 const ThemeContext = createContext()
 
 export function ThemeProvider({ children }) {
+  // Track whether the user has manually set a preference so we don't
+  // override it when the OS theme changes.
+  const userHasSetPreference = useRef(!!localStorage.getItem('nutriguard-theme-manual'))
+
   const [theme, setTheme] = useState(() => {
     // Check localStorage first
     const saved = localStorage.getItem('nutriguard-theme')
     if (saved) return saved
-    
+
     // Fallback to system preference
     if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
       return 'light'
     }
-    
+
     return 'dark' // Default to dark
   })
 
   useEffect(() => {
     // Save to localStorage
     localStorage.setItem('nutriguard-theme', theme)
-    
+
     // Set data-theme attribute on html element
     document.documentElement.setAttribute('data-theme', theme)
-    
+
     // Add theme class to body for better control
     if (theme === 'dark') {
       document.body.classList.add('dark-theme')
@@ -33,7 +37,27 @@ export function ThemeProvider({ children }) {
     }
   }, [theme])
 
+  // Listen for OS-level theme changes and sync automatically unless the
+  // user has already made an explicit manual choice.
+  useEffect(() => {
+    if (!window.matchMedia) return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const handleSystemThemeChange = (e) => {
+      if (!userHasSetPreference.current) {
+        setTheme(e.matches ? 'dark' : 'light')
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleSystemThemeChange)
+    return () => mediaQuery.removeEventListener('change', handleSystemThemeChange)
+  }, [])
+
   const toggleTheme = () => {
+    // Mark that the user has explicitly chosen a theme so OS changes are ignored.
+    userHasSetPreference.current = true
+    localStorage.setItem('nutriguard-theme-manual', '1')
     setTheme(prev => prev === 'dark' ? 'light' : 'dark')
   }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,7 +6,11 @@ import "./i18n";
 import './index.css'
 
 
-const savedTheme = localStorage.getItem('nutriguard-theme') || 'dark'
+const savedTheme =
+  localStorage.getItem('nutriguard-theme') ||
+  (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+    ? 'light'
+    : 'dark')
 document.documentElement.setAttribute('data-theme', savedTheme)
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
Added system preference auto-detection and persistent theme storage.

## Changes
- `ThemeContext.jsx` - Auto-detect OS theme on first visit
- `localStorage` persistence for theme choice
- Listen for system preference changes in real-time

## What's Fixed
- ✅ Auto-detects dark/light on first visit
- ✅ Theme persists across browser sessions
- ✅ Responds to OS theme changes dynamically

@Gagan021-5 please review!